### PR TITLE
Add dotEnv Configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Remove the .example extension on this file to activate it. Change the settings below as needed
+# to customize it for your environment. (These are the default settings if you are using Laravel
+# Homestead for development environment, although you will probably want to change the database.
+
 DB_NAME=homestead
 DB_USER=homestead
 DB_PASSWORD=secret

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_NAME=homestead
+DB_USER=homestead
+DB_PASSWORD=secret
+DEBUG=true

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 # WordPress: Uploads
 /content/uploads/*
 !/content/uploads/index.php
+
+# dotEnv Configuration:
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .DS_Store
 
 # PHPStorm
-.idea
+.idea/*
+!.idea/workspace.xml
 
 # Composer
 /vendor/

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ PHP 5.3.2+
 ```bash
 $ composer create-project wpscholar/wp-skeleton {directory}
 $ cd {directory}
-$ mv sample-wp-config-local.php wp-config-local.php
+$ mv .env.example .env
 ```

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
 	],
 	"require": {
 		"johnpbloch/wordpress": "*@stable",
-		"composer/installers": "*@stable"
+		"composer/installers": "*@stable",
+		"vlucas/phpdotenv": "~1.1"
 	},
 	"suggest": {
 		"wp-cli/wp-cli": "*@stable"

--- a/sample-wp-config-local.php
+++ b/sample-wp-config-local.php
@@ -1,5 +1,0 @@
-<?php
-
-define( 'DB_NAME', '%%DB_NAME%%' );
-define( 'DB_USER', '%%DB_USER%%' );
-define( 'DB_PASSWORD', '%%DB_PASSWORD%%' );

--- a/wp-config-local.php
+++ b/wp-config-local.php
@@ -1,0 +1,10 @@
+<?php
+
+require_once(__DIR__ . '/vendor/autoload.php');
+
+Dotenv::load(__DIR__);
+
+define( 'DB_NAME', getenv('DB_NAME'));
+define( 'DB_USER', getenv('DB_USER'));
+define( 'DB_PASSWORD', getenv('DB_PASSWORD'));
+define( 'WP_DEBUG', getenv('DEBUG') );


### PR DESCRIPTION
Adding functionality to allow dotEnv configuration. This is quickly becoming a best practice, as it allows you to keep your keys and secrets out of version control, and instead only requires the setup of dotEnv files in each environment. (For example using Laravel Forge for server deployment makes this a synch.)
